### PR TITLE
fix(merge-layers): guard against prototype pollution via YAML keys

### DIFF
--- a/src/utils/merge-layers/merge-layers.spec.ts
+++ b/src/utils/merge-layers/merge-layers.spec.ts
@@ -286,4 +286,45 @@ describe('merge-layers', () => {
     expect((({}) as any).polluted).toBeUndefined();
     expect(result[0]).not.toHaveProperty('__proto__');
   });
+
+  it('should ignore constructor key during merge', () => {
+    const malicious = JSON.parse('{"constructor":{"prototype":{"polluted":true}},"name":"safe"}');
+
+    const result = mergeDocuments({}, malicious);
+    expect((({}) as any).polluted).toBeUndefined();
+    expect(result[0]).not.toHaveProperty('constructor');
+    expect(result[0]).toEqual({ name: 'safe' });
+  });
+
+  it('should ignore prototype key during merge', () => {
+    const malicious = JSON.parse('{"prototype":{"polluted":true},"name":"safe"}');
+
+    const result = mergeDocuments({}, malicious);
+    expect((({}) as any).polluted).toBeUndefined();
+    expect(result[0]).not.toHaveProperty('prototype');
+    expect(result[0]).toEqual({ name: 'safe' });
+  });
+
+  it('should ignore unsafe keys recursively in nested objects', () => {
+    const mockA = { config: { setting: 'value' } };
+    const malicious = JSON.parse('{"config":{"setting":"overwrite","__proto__":{"polluted":true},"constructor":{"bad":true}}}');
+
+    const result = mergeDocuments(mockA, malicious);
+    expect((({}) as any).polluted).toBeUndefined();
+    expect(result[0]).toEqual({ config: { setting: 'overwrite' } });
+    expect(result[0]!['config']).not.toHaveProperty('__proto__');
+    expect(result[0]!['config']).not.toHaveProperty('constructor');
+  });
+
+  it('should reject unsafe name values in array merge path', () => {
+    const mockA = {
+      users: [{ name: '__proto__', value: 1 }],
+    };
+    const mockB = {
+      users: [{ name: 'safeUser', value: 2 }],
+    };
+
+    const result = mergeDocuments(mockA, mockB);
+    expect(result[0]).toEqual({ users: [{ name: 'safeUser', value: 2 }] });
+  });
 });

--- a/src/utils/merge-layers/merge-layers.spec.ts
+++ b/src/utils/merge-layers/merge-layers.spec.ts
@@ -278,4 +278,12 @@ describe('merge-layers', () => {
       ),
     ]);
   });
+
+  it('should not allow prototype-polluting keys to be merged', () => {
+    const malicious = JSON.parse('{"__proto__":{"polluted":true},"name":"safe"}');
+
+    const result = mergeDocuments({}, malicious);
+    expect((({}) as any).polluted).toBeUndefined();
+    expect(result[0]).not.toHaveProperty('__proto__');
+  });
 });

--- a/src/utils/merge-layers/merge-layers.ts
+++ b/src/utils/merge-layers/merge-layers.ts
@@ -5,6 +5,9 @@
 
 type MergedDocument = { [key: string]: any };
 
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const isUnsafeKey = (key: string): boolean => UNSAFE_KEYS.has(key);
+
 /**
  * Merge multiple IFEX documents into one document.
  * It takes the order of the documents into account. The last document has the highest priority
@@ -19,7 +22,7 @@ export const mergeDocuments = (...docs: Record<string, unknown>[]): [MergedDocum
 
   for (const overlayDoc of docs) {
     for (const [key, overlayValue] of Object.entries(overlayDoc)) {
-      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      if (isUnsafeKey(key)) {
         continue;
       }
       const baseValue = mergedMap[key];
@@ -141,7 +144,7 @@ const getNameAttribute = (value: unknown): [MergedDocument | null, boolean, stri
   }
 
   const nameValue = valueMap['name'];
-  if (typeof nameValue === 'string' && nameValue !== '__proto__' && nameValue !== 'constructor' && nameValue !== 'prototype') {
+  if (typeof nameValue === 'string' && !isUnsafeKey(nameValue)) {
     return [valueMap, true, nameValue];
   }
 

--- a/src/utils/merge-layers/merge-layers.ts
+++ b/src/utils/merge-layers/merge-layers.ts
@@ -19,6 +19,9 @@ export const mergeDocuments = (...docs: Record<string, unknown>[]): [MergedDocum
 
   for (const overlayDoc of docs) {
     for (const [key, overlayValue] of Object.entries(overlayDoc)) {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        continue;
+      }
       const baseValue = mergedMap[key];
       const exists = baseValue !== undefined;
 
@@ -138,7 +141,7 @@ const getNameAttribute = (value: unknown): [MergedDocument | null, boolean, stri
   }
 
   const nameValue = valueMap['name'];
-  if (typeof nameValue === 'string') {
+  if (typeof nameValue === 'string' && nameValue !== '__proto__' && nameValue !== 'constructor' && nameValue !== 'prototype') {
     return [valueMap, true, nameValue];
   }
 


### PR DESCRIPTION
## Summary

- YAML documents can contain keys like `__proto__`, `constructor`, or `prototype` that, when used as JS object property names during merging, can pollute the Object prototype.
- `mergeDocuments` now skips any top-level key matching those names.
- `getNameAttribute` also rejects those strings as `name` attribute values so they cannot become keys in the named-item maps inside `mergeArrays`.
- A regression test is included that asserts `{}.polluted` remains `undefined` after merging a crafted payload.
