### PR TITLE
fix(sidenav): remove mouseup listener after each resize interaction

### DIFF
--- a/src/components/sidenav/Sidenav.vue
+++ b/src/components/sidenav/Sidenav.vue
@@ -124,11 +124,13 @@ const sidenavSize = ref(350); // TODO: set initial size dynamically by the curre
 const sidenavEl = ref<HTMLDivElement | null>(null);
 
 // TODO: set min-width for sidenav
+const stopResizing = () => {
+  document.removeEventListener('mousemove', resize);
+};
+
 const startResizing = () => {
   document.addEventListener('mousemove', resize);
-  document.addEventListener('mouseup', () => {
-    document.removeEventListener('mousemove', resize);
-  });
+  document.addEventListener('mouseup', stopResizing, { once: true });
 };
 
 const onTabChange = (tabName: string) => {


### PR DESCRIPTION
## Summary

- Each `mousedown` on the resize handle called `document.addEventListener('mouseup', () => {...})` with an anonymous closure, so the `mouseup` listener was never removed — a new one accumulated on every drag attempt.
- Extracted the handler as a named `stopResizing` function and passed `{ once: true }` to `addEventListener`, so the browser removes it automatically after the first `mouseup`.
- No behaviour change; the fix is purely about listener hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)