### PR TITLE
fix(tree): guard createTreeModel against non-array nodes input

### DIFF
--- a/src/utils/tree/tree.spec.ts
+++ b/src/utils/tree/tree.spec.ts
@@ -26,6 +26,11 @@ describe('tree', () => {
   afterEach(() => vi.restoreAllMocks());
 
   describe('should generate tree', () => {
+    it('should return empty array when nodes is not an array', () => {
+      const result = createTreeModel(null as unknown as Array<Namespace>);
+      expect(result).toEqual([]);
+    });
+
     it('with namespaces only', () => {
       const id1 = '1234';
       const id2 = '12345';

--- a/src/utils/tree/tree.ts
+++ b/src/utils/tree/tree.ts
@@ -97,6 +97,8 @@ export const createTreeModel = (
   validationErrors: Map<string, ErrorObject[]> = new Map<string, ErrorObject[]>(),
   isInterface = false,
 ): IFEXTreeModelNode[] => {
+  if (!Array.isArray(nodes)) return [];
+
   return nodes.map((node, currNodeIndex): IFEXTreeModelNode => {
     const currentPath = `${path}/${currNodeIndex}`;
     const children = [];


### PR DESCRIPTION
## Summary

- A YAML document can legally contain a scalar or `null` where an array is expected (e.g. `namespaces: ~`). In that case `nodes.map()` throws a `TypeError` at runtime.
- Added an `Array.isArray(nodes)` guard at the top of `createTreeModel` that returns `[]` immediately for non-array input, consistent with the existing guard in `createLeafNode`.
- Included a unit test that passes `null` as `nodes` and asserts an empty array is returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)