### PR TITLE
fix(source-code-viewer): re-highlight when code prop changes

### DIFF
--- a/src/components/shared/components/source-code-viewer/SourceCodeViewer.vue
+++ b/src/components/shared/components/source-code-viewer/SourceCodeViewer.vue
@@ -34,9 +34,9 @@ const unknownPropsYaml = computed(() => YAML.stringify(code));
 
 const codeBlock = useTemplateRef<HTMLElement>('code');
 
-watch(codeBlock, () => {
+watch(unknownPropsYaml, () => {
   if (codeBlock.value) {
     hljs.highlightElement(codeBlock.value);
   }
-});
+}, { immediate: true, flush: 'post' });
 </script>


### PR DESCRIPTION
## Summary

- The existing `watch(codeBlock, ...)` fires once when the `<code>` element is first added to the DOM, but not again when the `code` prop changes (the element identity stays the same).
- Navigating between nodes updates `unknownPropsYaml` but highlight.js was never re-invoked, leaving subsequent code blocks unstyled.
- Changed the watch source to `unknownPropsYaml` with `{ immediate: true, flush: 'post' }` so the highlighter runs after every DOM update that carries new content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)