### PR TITLE
fix(search,custom-props): add depth guard and unsafe-key filter

### DIFF
--- a/src/components/sidenav/Sidenav.vue
+++ b/src/components/sidenav/Sidenav.vue
@@ -68,6 +68,7 @@ SPDX-FileCopyrightText: © 2025 Mercedes-Benz Tech Innovation GmbH
           v-if="searchValue.length"
           :search-results="searchResults"
           :search-query="searchValue"
+          :search-depth-limit-reached="searchDepthLimitReached"
           @search-result-selected="searchResult => onNodeSelected(searchResult.id)"
         />
 
@@ -112,7 +113,7 @@ const searchValue = ref('');
 
 const treeModelRef = computed(() => treeModel);
 
-const { searchResults } = useSearch(searchValue, treeModelRef);
+const { searchResults, searchDepthLimitReached } = useSearch(searchValue, treeModelRef);
 
 const { collapseAllNodes, expandAllNodes, onToggleChildren, treeNodes, allNodesExpanded } = useTree(treeModelRef, () => selectedNodeId);
 

--- a/src/components/sidenav/composables/use-search.ts
+++ b/src/components/sidenav/composables/use-search.ts
@@ -67,7 +67,13 @@ export const useSearch = (searchValue: Ref<string>, treeNodes: Ref<IFEXTreeModel
     return filteredNodes;
   };
 
-  const searchInContent = (valueToSearchIn: IFEXTreeModelNode['node'] | string | number, searchValue: string): boolean => {
+  const MAX_SEARCH_DEPTH = 20;
+
+  const searchInContent = (valueToSearchIn: IFEXTreeModelNode['node'] | string | number, searchValue: string, depth = 0): boolean => {
+    if (depth > MAX_SEARCH_DEPTH) {
+      return false;
+    }
+
     if (typeof valueToSearchIn === 'string') {
       return valueToSearchIn.toLowerCase().includes(searchValue);
     }
@@ -77,11 +83,11 @@ export const useSearch = (searchValue: Ref<string>, treeNodes: Ref<IFEXTreeModel
     }
 
     if (Array.isArray(valueToSearchIn)) {
-      return valueToSearchIn.some(item => searchInContent(item, searchValue));
+      return valueToSearchIn.some(item => searchInContent(item, searchValue, depth + 1));
     }
 
     if (typeof valueToSearchIn === 'object' && valueToSearchIn !== null) {
-      return Object.values(valueToSearchIn).some(value => searchInContent(value, searchValue));
+      return Object.values(valueToSearchIn).some(value => searchInContent(value, searchValue, depth + 1));
     }
 
     return false;

--- a/src/components/sidenav/composables/use-search.ts
+++ b/src/components/sidenav/composables/use-search.ts
@@ -9,13 +9,23 @@ import { SearchResult } from '../search-results/types.ts';
 import { BadgeType } from '../../shared/components/badge/types.ts';
 import { Interface, Namespace } from '../../../types/ifex-core.ts';
 
+const MAX_SEARCH_DEPTH = 20;
+
 export const useSearch = (searchValue: Ref<string>, treeNodes: Ref<IFEXTreeModelNode[]>) => {
+  let _depthLimitReached = false;
+
   const searchResults = computed(() => {
+    _depthLimitReached = false;
     if (!searchValue.value) {
       return [];
     }
 
     return filterTreeNodes(treeNodes.value, searchValue.value.toLowerCase());
+  });
+
+  const searchDepthLimitReached = computed(() => {
+    void searchResults.value;
+    return _depthLimitReached;
   });
 
   const filterTreeNodes = (treeNodes: IFEXTreeModelNode[], searchValue: string): SearchResult[] => {
@@ -67,10 +77,9 @@ export const useSearch = (searchValue: Ref<string>, treeNodes: Ref<IFEXTreeModel
     return filteredNodes;
   };
 
-  const MAX_SEARCH_DEPTH = 20;
-
   const searchInContent = (valueToSearchIn: IFEXTreeModelNode['node'] | string | number, searchValue: string, depth = 0): boolean => {
     if (depth > MAX_SEARCH_DEPTH) {
+      _depthLimitReached = true;
       return false;
     }
 
@@ -93,5 +102,5 @@ export const useSearch = (searchValue: Ref<string>, treeNodes: Ref<IFEXTreeModel
     return false;
   };
 
-  return { searchResults };
+  return { searchResults, searchDepthLimitReached };
 };

--- a/src/components/sidenav/search-results/SearchResults.vue
+++ b/src/components/sidenav/search-results/SearchResults.vue
@@ -4,6 +4,9 @@ SPDX-FileCopyrightText: © 2025 Mercedes-Benz Tech Innovation GmbH
 -->
 <template>
   <div class="flex flex-col">
+    <p v-if="searchDepthLimitReached" class="text-xs text-amber-600 dark:text-amber-400 px-1 pb-2">
+      Some results may be missing — content nested beyond 20 levels was not searched.
+    </p>
     <p v-if="searchResults.length === 0" class="text-center text-gray-400">
       No search results found<template v-if="searchQuery.length > 0"> for "{{ searchQuery }}"</template>.
     </p>

--- a/src/components/sidenav/search-results/types.ts
+++ b/src/components/sidenav/search-results/types.ts
@@ -3,6 +3,7 @@ import { BadgeType } from '../../shared/components/badge/types.ts';
 export interface SearchResultsProps {
   searchResults: SearchResult[];
   searchQuery: string;
+  searchDepthLimitReached?: boolean;
 }
 
 export interface SearchResult {

--- a/src/utils/get-custom-properties/get-custom-properties.spec.ts
+++ b/src/utils/get-custom-properties/get-custom-properties.spec.ts
@@ -43,4 +43,13 @@ describe('get-custom-properties', () => {
       },
     });
   });
+
+  it('should not include unsafe keys such as __proto__, constructor and prototype', () => {
+    const malicious = JSON.parse('{"__proto__":{"polluted":true},"constructor":"evil","name":"safe","custom_field":"value"}');
+    const result = getCustomProperties(malicious, knownNamespaceProperties);
+
+    expect(result).not.toHaveProperty('__proto__');
+    expect(result).not.toHaveProperty('constructor');
+    expect(result).toHaveProperty('custom_field', 'value');
+  });
 });

--- a/src/utils/get-custom-properties/get-custom-properties.ts
+++ b/src/utils/get-custom-properties/get-custom-properties.ts
@@ -3,12 +3,12 @@
  * SPDX-FileCopyrightText: © 2025 Mercedes-Benz Tech Innovation GmbH
  */
 
-const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+import { isUnsafeKey } from '../unsafe-keys/unsafe-keys.ts';
 
 export const getCustomProperties = <T>(node: T, knownProperties: Record<keyof T, undefined>) => {
   const allKnownProperties = Object.keys(knownProperties) as (keyof T)[];
   const unknownKeys = Object.keys(node as object).filter(
-    key => !UNSAFE_KEYS.has(key) && !allKnownProperties.includes(key as keyof T),
+    key => !isUnsafeKey(key) && !allKnownProperties.includes(key as keyof T),
   );
 
   const unknownPropsObj: Record<string, unknown> = {};

--- a/src/utils/get-custom-properties/get-custom-properties.ts
+++ b/src/utils/get-custom-properties/get-custom-properties.ts
@@ -3,14 +3,20 @@
  * SPDX-FileCopyrightText: © 2025 Mercedes-Benz Tech Innovation GmbH
  */
 
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 export const getCustomProperties = <T>(node: T, knownProperties: Record<keyof T, undefined>) => {
   const allKnownProperties = Object.keys(knownProperties) as (keyof T)[];
-  const unknownKeys = Object.keys(node as object).filter(key => !allKnownProperties.includes(key as keyof T));
+  const unknownKeys = Object.keys(node as object).filter(
+    key => !UNSAFE_KEYS.has(key) && !allKnownProperties.includes(key as keyof T),
+  );
 
   const unknownPropsObj: Record<string, unknown> = {};
 
   for (const key of unknownKeys) {
-    unknownPropsObj[key] = node[key as keyof T];
+    if (Object.prototype.hasOwnProperty.call(node, key)) {
+      unknownPropsObj[key] = node[key as keyof T];
+    }
   }
 
   return unknownPropsObj;

--- a/src/utils/unsafe-keys/unsafe-keys.ts
+++ b/src/utils/unsafe-keys/unsafe-keys.ts
@@ -1,0 +1,7 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: © 2025 Mercedes-Benz Tech Innovation GmbH
+ */
+
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+export const isUnsafeKey = (key: string): boolean => UNSAFE_KEYS.has(key);


### PR DESCRIPTION
## Summary

Two tightly related defensive input guards bundled in one PR:

**`use-search.ts`** — `searchInContent` recurses through every nested object value without a depth limit. A deeply-nested or deliberately crafted YAML document could exhaust the call stack and crash the browser tab. A `MAX_SEARCH_DEPTH` constant (20 levels) now caps the recursion; deeper branches are treated as non-matching.

**`get-custom-properties.ts`** — Keys such as `__proto__`, `constructor`, and `prototype` are now filtered before being written into the result object, and each property read is guarded with `Object.prototype.hasOwnProperty.call` to prevent inadvertent prototype-chain access. A unit test covers the unsafe-key scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)